### PR TITLE
Added ability to search for instruments using a predicate

### DIFF
--- a/QDMS.Server/Brokers/ContinuousFuturesBroker.cs
+++ b/QDMS.Server/Brokers/ContinuousFuturesBroker.cs
@@ -27,6 +27,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using System.Timers;
 using System.Windows;
@@ -939,14 +940,14 @@ namespace QDMSServer
             selectedDate = selectedDate.AddMonths(count);
 
             //we got the month we want! find the contract
-            var searchFunc = new Func<Instrument, bool>(
+            Expression<Func<Instrument, bool>> searchFunc = 
                 x =>
                     x.Expiration.HasValue &&
                     x.Expiration.Value.Month == selectedDate.Month &&
                     x.Expiration.Value.Year == selectedDate.Year &&
-                    x.UnderlyingSymbol == cf.UnderlyingSymbol.Symbol);
+                    x.UnderlyingSymbol == cf.UnderlyingSymbol.Symbol;
 
-            var contract = _instrumentMgr.FindInstruments(pred: searchFunc).FirstOrDefault();
+            var contract = _instrumentMgr.FindInstruments(searchFunc).FirstOrDefault();
 
 
             var timer = new Timer(50) { AutoReset = false };

--- a/QDMS.Server/Interfaces/IInstrumentSource.cs
+++ b/QDMS.Server/Interfaces/IInstrumentSource.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using EntityData;
 using QDMS;
 
@@ -20,7 +21,15 @@ namespace QDMSServer
         /// <param name="search">Any properties set on this instrument are used as search parameters.
         /// If null, all instruments are returned.</param>
         /// <returns>A list of instruments matching the criteria.</returns>
-        List<Instrument> FindInstruments(MyDBContext context = null, Instrument search = null, Func<Instrument, bool> pred = null);
+        List<Instrument> FindInstruments(MyDBContext context = null, Instrument search = null);
+
+        /// <summary>
+        /// Search for instruments.
+        /// </summary>
+        /// <param name="pred">An expression with the instrument search</param>
+        /// <param name="context"></param>
+        /// <returns>A list of instruments matching the criteria.</returns>
+        List<Instrument> FindInstruments(Expression<Func<Instrument, bool>> pred, MyDBContext context = null);
 
         /// <summary>
         /// Tries to add multiple instruments to the database.

--- a/QDMS.Server/QDMS.Server.csproj
+++ b/QDMS.Server/QDMS.Server.csproj
@@ -53,6 +53,10 @@
       <HintPath>..\packages\lz4net.1.0.10.93\lib\net4-client\LZ4.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="MetaLinq, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MetaLinq.1.0.11\lib\portable45-net45+win8+wp8+wpa81\MetaLinq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NetMQ, Version=3.3.3.4, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
       <HintPath>..\packages\NetMQ.3.3.3.4\lib\net40\NetMQ.dll</HintPath>
       <Private>True</Private>

--- a/QDMS.Server/packages.config
+++ b/QDMS.Server/packages.config
@@ -5,6 +5,7 @@
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="lz4net" version="1.0.10.93" targetFramework="net45" />
+  <package id="MetaLinq" version="1.0.11" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net452" />

--- a/QDMSClient/QDMSClient.csproj
+++ b/QDMSClient/QDMSClient.csproj
@@ -44,6 +44,10 @@
       <HintPath>..\packages\lz4net.1.0.10.93\lib\net4-client\LZ4.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="MetaLinq, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MetaLinq.1.0.11\lib\portable45-net45+win8+wp8+wpa81\MetaLinq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NetMQ, Version=3.3.3.4, Culture=neutral, PublicKeyToken=a6decef4ddc58b3a, processorArchitecture=MSIL">
       <HintPath>..\packages\NetMQ.3.3.3.4\lib\net40\NetMQ.dll</HintPath>
       <Private>True</Private>

--- a/QDMSClient/packages.config
+++ b/QDMSClient/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="AsyncIO" version="0.1.26.0" targetFramework="net45" />
   <package id="lz4net" version="1.0.10.93" targetFramework="net45" />
+  <package id="MetaLinq" version="1.0.11" targetFramework="net45" />
   <package id="NetMQ" version="3.3.3.4" targetFramework="net45" />
   <package id="NodaTime" version="1.3.2" targetFramework="net45" />
   <package id="protobuf-net" version="2.1.0" targetFramework="net45" />

--- a/QDMSTest/QDMSServer/ContinuousFuturesBrokerTest.cs
+++ b/QDMSTest/QDMSServer/ContinuousFuturesBrokerTest.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using EntityData;
 using Moq;
@@ -76,7 +77,7 @@ namespace QDMSTest
         [Test]
         public void SearchesForCorrectContracts()
         {
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(new List<Instrument>());
+            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>())).Returns(new List<Instrument>());
 
             _broker.RequestHistoricalData(_req);
 
@@ -85,7 +86,7 @@ namespace QDMSTest
                     i.UnderlyingSymbol == _cfInst.ContinuousFuture.UnderlyingSymbol.Symbol &&
                     i.Type == InstrumentType.Future &&
                     i.DatasourceID == _cfInst.DatasourceID
-                ), null));
+                )));
         }
 
         //This tests the request to the client for historical data, ensuring that the right contracts are requested
@@ -93,7 +94,9 @@ namespace QDMSTest
         public void RequestsDataOnCorrectContracts()
         {
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var requests = new List<HistoricalDataRequest>();
 
@@ -211,7 +214,9 @@ namespace QDMSTest
             };
 
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var requests = new List<HistoricalDataRequest>();
             var futuresData = ContinuousFuturesBrokerTestData.GetVIXFuturesData();
@@ -318,7 +323,9 @@ namespace QDMSTest
             };
 
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var requests = new List<HistoricalDataRequest>();
             var futuresData = ContinuousFuturesBrokerTestData.GetVIXFuturesData();
@@ -470,7 +477,9 @@ namespace QDMSTest
             };
 
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var requests = new List<HistoricalDataRequest>();
             var futuresData = ContinuousFuturesBrokerTestData.GetVIXFuturesData();
@@ -517,7 +526,9 @@ namespace QDMSTest
         public void BrokerReturnsCorrectDateRange()
         {
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var requests = new List<HistoricalDataRequest>();
             var futuresData = ContinuousFuturesBrokerTestData.GetVIXFuturesData();
@@ -665,7 +676,9 @@ namespace QDMSTest
             };
 
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var requests = new List<HistoricalDataRequest>();
             var futuresData = ContinuousFuturesBrokerTestData.GetVIXFuturesData();
@@ -817,7 +830,9 @@ namespace QDMSTest
             };
 
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var requests = new List<HistoricalDataRequest>();
             var futuresData = ContinuousFuturesBrokerTestData.GetVIXFuturesData();
@@ -969,7 +984,9 @@ namespace QDMSTest
             };
 
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var requests = new List<HistoricalDataRequest>();
             var futuresData = ContinuousFuturesBrokerTestData.GetVIXFuturesData();
@@ -1102,7 +1119,9 @@ namespace QDMSTest
             _req.EndingDate = new DateTime(2013, 3, 1);
 
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var requests = new List<HistoricalDataRequest>();
             var futuresData = ContinuousFuturesBrokerTestData.GetVIXFuturesData();
@@ -1239,7 +1258,9 @@ namespace QDMSTest
             _req.EndingDate = new DateTime(2013, 3, 1);
 
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var requests = new List<HistoricalDataRequest>();
             var futuresData = ContinuousFuturesBrokerTestData.GetVIXFuturesData();
@@ -1371,7 +1392,9 @@ namespace QDMSTest
             };
 
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var requests = new List<HistoricalDataRequest>();
             var futuresData = ContinuousFuturesBrokerTestData.GetVIXFuturesData();
@@ -1420,9 +1443,9 @@ namespace QDMSTest
 
             //return the contracts requested
             _instrumentMgrMock.Setup(x => x
-                .FindInstruments(null, null, It.IsAny<Func<Instrument, bool>>()))
+                .FindInstruments(It.IsAny<Expression<Func<Instrument, bool>>>(), null))
                 .Returns(
-                    (MyDBContext a, Instrument b, Func<Instrument, bool> y) => contracts.Where(y).ToList()
+                    (Expression<Func<Instrument, bool>> y, MyDBContext a) => contracts.AsQueryable().Where(y).ToList()
                 );
 
             _cfInst.ContinuousFuture.RolloverDays = 1;
@@ -1544,7 +1567,9 @@ namespace QDMSTest
         public void FindFrontContractFindsCorrectContractVolumeBased()
         {
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var expectedExpirationMonths = new Dictionary<DateTime, int>
             {
@@ -1701,9 +1726,9 @@ namespace QDMSTest
 
             //return the contracts requested
             _instrumentMgrMock.Setup(x => x
-                .FindInstruments(null, null, It.IsAny<Func<Instrument, bool>>()))
+                .FindInstruments(It.IsAny<Expression<Func<Instrument, bool>>>(), null))
                 .Returns(
-                    (MyDBContext a, Instrument b, Func<Instrument, bool> y) => contracts.Where(y).ToList()
+                    (Expression<Func<Instrument, bool>> y, MyDBContext a) => contracts.AsQueryable().Where(y).ToList()
                 );
 
             _cfInst.ContinuousFuture.RolloverDays = 1;
@@ -1829,9 +1854,9 @@ namespace QDMSTest
 
             //return the contracts requested
             _instrumentMgrMock.Setup(x => x
-                .FindInstruments(null, null, It.IsAny<Func<Instrument, bool>>()))
+                .FindInstruments(It.IsAny<Expression<Func<Instrument, bool>>>(), It.IsAny<MyDBContext>()))
                 .Returns(
-                    (MyDBContext a, Instrument b, Func<Instrument, bool> y) => contracts.Where(y).ToList()
+                    (Expression<Func<Instrument, bool>> y, MyDBContext a) => contracts.AsQueryable().Where(y).ToList()
                 );
 
             _cfInst.ContinuousFuture.RolloverDays = 1;
@@ -1961,7 +1986,9 @@ namespace QDMSTest
         public void FindFrontContractFindsCorrectContractOpenInterestBased()
         {
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetVIXFutures());
 
             var expectedExpirationMonths = new Dictionary<DateTime, int>
             {
@@ -2188,7 +2215,9 @@ namespace QDMSTest
             };
 
             //return the contracts requested
-            _instrumentMgrMock.Setup(x => x.FindInstruments(null, It.IsAny<Instrument>(), null)).Returns(ContinuousFuturesBrokerTestData.GetContractsForIntradayData());
+            _instrumentMgrMock
+                .Setup(x => x.FindInstruments(null, It.IsAny<Instrument>()))
+                .Returns(ContinuousFuturesBrokerTestData.GetContractsForIntradayData());
 
             var requests = new List<HistoricalDataRequest>();
             var futuresData = ContinuousFuturesBrokerTestData.GetIntradayVIXFuturesData();

--- a/QDMSTest/QDMSServer/DataUpdateJobTest.cs
+++ b/QDMSTest/QDMSServer/DataUpdateJobTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -58,7 +59,7 @@ namespace QDMSTest
 
             Instrument inst = new Instrument() { ID = 1, Symbol = "SPY", Currency = "USD", Type = InstrumentType.Stock };
             _instrumentManagerMock
-                .Setup(x => x.FindInstruments(It.IsAny<MyDBContext>(), It.IsAny<Instrument>(), It.IsAny<Func<Instrument, bool>>()))
+                .Setup(x => x.FindInstruments(It.IsAny<Expression<Func<Instrument, bool>>>(), It.IsAny<MyDBContext>()))
                 .Returns(new List<Instrument>() { inst });
 
             _localStorageMock
@@ -93,7 +94,7 @@ namespace QDMSTest
 
             Instrument inst = new Instrument() { ID = 1, Symbol = "SPY", Currency = "USD", Type = InstrumentType.Stock };
             _instrumentManagerMock
-                .Setup(x => x.FindInstruments(It.IsAny<MyDBContext>(), It.IsAny<Instrument>(), It.IsAny<Func<Instrument, bool>>()))
+                .Setup(x => x.FindInstruments(It.IsAny<Expression<Func<Instrument, bool>>>(), It.IsAny<MyDBContext>()))
                 .Returns(new List<Instrument>() { inst });
 
             _localStorageMock
@@ -125,7 +126,7 @@ namespace QDMSTest
 
             Instrument inst = new Instrument() { ID = 1, Symbol = "SPY", Currency = "USD", Type = InstrumentType.Stock };
             _instrumentManagerMock
-                .Setup(x => x.FindInstruments(It.IsAny<MyDBContext>(), It.IsAny<Instrument>(), It.IsAny<Func<Instrument, bool>>()))
+                .Setup(x => x.FindInstruments(It.IsAny<Expression<Func<Instrument, bool>>>(), It.IsAny<MyDBContext>()))
                 .Returns(new List<Instrument>() { inst });
 
             _localStorageMock
@@ -156,7 +157,7 @@ namespace QDMSTest
 
             Instrument inst = new Instrument() { ID = 1, Symbol = "SPY", Currency = "USD", Type = InstrumentType.Stock };
             _instrumentManagerMock
-                .Setup(x => x.FindInstruments(It.IsAny<MyDBContext>(), It.IsAny<Instrument>(), It.IsAny<Func<Instrument, bool>>()))
+                .Setup(x => x.FindInstruments(It.IsAny<Expression<Func<Instrument, bool>>>(), It.IsAny<MyDBContext>()))
                 .Returns(new List<Instrument>() { inst });
 
             _localStorageMock
@@ -198,7 +199,7 @@ namespace QDMSTest
 
             Instrument inst = new Instrument() { ID = 1, Symbol = "SPY", Currency = "USD", Type = InstrumentType.Stock };
             _instrumentManagerMock
-                .Setup(x => x.FindInstruments(It.IsAny<MyDBContext>(), It.IsAny<Instrument>(), It.IsAny<Func<Instrument, bool>>()))
+                .Setup(x => x.FindInstruments(It.IsAny<Expression<Func<Instrument, bool>>>(), It.IsAny<MyDBContext>()))
                 .Returns(new List<Instrument>() { inst });
 
             _localStorageMock

--- a/QDMSTest/QDMSTest.csproj
+++ b/QDMSTest/QDMSTest.csproj
@@ -62,6 +62,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Libraries\ib-csharp\Krs.Ats.IBNet.dll</HintPath>
     </Reference>
+    <Reference Include="MetaLinq, Version=1.0.11.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MetaLinq.1.0.11\lib\portable45-net45+win8+wp8+wpa81\MetaLinq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Moq, Version=4.5.19.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.5.19\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>

--- a/QDMSTest/packages.config
+++ b/QDMSTest/packages.config
@@ -4,6 +4,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
+  <package id="MetaLinq" version="1.0.11" targetFramework="net45" />
   <package id="Moq" version="4.5.19" targetFramework="net45" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />

--- a/SampleApp/Program.cs
+++ b/SampleApp/Program.cs
@@ -58,7 +58,7 @@ namespace SampleApp
             
             //then we grab some historical data from Yahoo
             //start by finding the SPY instrument
-            var spy = instruments.FirstOrDefault(x => x.Symbol == "SPY" && x.Datasource.Name == "Yahoo");
+            var spy = client.FindInstruments(x => x.Symbol == "SPY" && x.Datasource.Name == "Yahoo").FirstOrDefault();
             if (spy != null)
             {
                 var req = new HistoricalDataRequest(


### PR DESCRIPTION
using MetaLinq to serialize the predicates for transfer between client/server.

Instead of the cumbersome search based on filling in an Instrument object, you can now simply use LINQ, e.g.

`client.FindInstrument(x => x.UnderlyingSymbol == "SPY" 
&& x.Expiration > new DateTime(2016,1,1) 
&& x.Type == InstrumentType.Option
&& x.OptionType == OptionType.Call) `