### PR TITLE
Fixed IB contract ambiguity problem 

### DIFF
--- a/QDMSServer/Utils/TWSUtils.cs
+++ b/QDMSServer/Utils/TWSUtils.cs
@@ -225,7 +225,7 @@ namespace QDMSServer
                 instrument.Multiplier.ToString(),
                 "",
                 instrument.Currency,
-                null,
+                instrument.Symbol,
                 instrument.PrimaryExchange == null ? null : instrument.PrimaryExchange.Name,
                 SecurityIdType.None,
                 string.Empty);


### PR DESCRIPTION
When multiple futures on the same underlying expired in the same month, the contract would be ambiguous and IB couldn't send data. Fixed by setting LocalSymbol when converting from Instrument to IB Contract.