### PR TITLE
Fixed a couple of migration issues

### DIFF
--- a/EntityData/Migrations/201609021302442_TradingClass.Designer.cs
+++ b/EntityData/Migrations/201609021302442_TradingClass.Designer.cs
@@ -18,7 +18,7 @@ namespace EntityData.Migrations
         
         string IMigrationMetadata.Source
         {
-            get { return Resources.GetString("Source"); }
+            get { return null; }
         }
         
         string IMigrationMetadata.Target

--- a/EntityData/Migrations/201609140220190_IndexFix.cs
+++ b/EntityData/Migrations/201609140220190_IndexFix.cs
@@ -1,3 +1,5 @@
+using System.Configuration;
+
 namespace EntityData.Migrations.DataDBContextNS
 {
     using System;
@@ -7,8 +9,18 @@ namespace EntityData.Migrations.DataDBContextNS
     {
         public override void Up()
         {
-            DropPrimaryKey("dbo.data");
-            AddPrimaryKey("dbo.data", new[] { "InstrumentID", "Frequency", "DT" });
+            string provider = ConfigurationManager.ConnectionStrings["qdmsEntities"].ProviderName;
+
+            if (provider == "MySql.Data.MySqlClient")
+            {
+                DropPrimaryKey("data");
+                AddPrimaryKey("data", new[] { "InstrumentID", "Frequency", "DT" });
+            }
+            else
+            {
+                DropPrimaryKey("dbo.data");
+                AddPrimaryKey("dbo.data", new[] { "InstrumentID", "Frequency", "DT" });
+            }
         }
         
         public override void Down()

--- a/QDMSTest/App.config
+++ b/QDMSTest/App.config
@@ -11,8 +11,12 @@
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
-    </providers>
+    <provider invariantName="MySql.Data.MySqlClient" type="MySql.Data.MySqlClient.MySqlProviderServices, MySql.Data.Entity.EF6, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"></provider></providers>
   </entityFramework>
+  <connectionStrings>
+    <add name="qdmsEntities" connectionString="" providerName="MySql.Data.MySqlClient" />
+    <add name="qdmsDataEntities" connectionString="" providerName="MySql.Data.MySqlClient" />
+  </connectionStrings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
@@ -57,4 +61,9 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<system.data>
+    <DbProviderFactories>
+      <remove invariant="MySql.Data.MySqlClient" />
+      <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
+    </DbProviderFactories>
+  </system.data></configuration>

--- a/QDMSTest/QDMS/DbCreationTest.cs
+++ b/QDMSTest/QDMS/DbCreationTest.cs
@@ -1,0 +1,157 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="DbCreationTest.cs" company="">
+// Copyright 2016 Alexander Soffronow Pagonidis
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Configuration;
+using System.Data.Entity;
+using System.Data.SqlClient;
+using System.Reflection;
+using MySql.Data.MySqlClient;
+using NUnit.Framework;
+using EntityData;
+using MySql.Data.Entity;
+
+namespace QDMSTest
+{
+    [TestFixture]
+    public class DbCreationTest
+    {
+        private readonly string _mySqlPassword = "Password12!";
+        private readonly string _mySqlUsername = "root";
+        private readonly string _mySqlHost = "127.0.0.1";
+
+        private readonly string _sqlServerPassword = "Password12!";
+        private readonly string _sqlServerHost = "(local)\\SQL2016";
+        private readonly string _sqlServerUsername = "as";
+        private readonly bool _useWindowsAuthentication = false;
+
+        [Test]
+        public void MySqlDbIsCreatedSuccessfully()
+        {
+            using (var conn = new MySqlConnection(GetMySqlConnString(_mySqlUsername, _mySqlPassword, _mySqlHost)))
+            {
+                conn.Open();
+                using (var cmd = new MySqlCommand("", conn))
+                {
+                    cmd.CommandText = @"DROP DATABASE IF EXISTS qdms_test;
+                                        CREATE DATABASE qdms_test;
+                                        DROP DATABASE IF EXISTS qdmsdata_test;
+                                        CREATE DATABASE qdmsdata_test;";
+                    cmd.ExecuteNonQuery();
+                }
+            }
+
+            SetConnectionString("qdmsEntities", GetMySqlConnString(_mySqlUsername, _mySqlPassword, _mySqlHost, "qdms_test"), "MySql.Data.MySqlClient");
+            SetConnectionString("qdmsDataEntities", GetMySqlConnString(_mySqlUsername, _mySqlPassword, _mySqlHost, "qdmsdata_test"), "MySql.Data.MySqlClient");
+
+            ConfigurationManager.RefreshSection("connectionStrings");
+
+            DbConfiguration.SetConfiguration(new MySqlEFConfiguration());
+
+            using (var ctx = new MyDBContext())
+            {
+                ctx.Database.Initialize(true);
+            }
+
+            using (var ctx = new DataDBContext())
+            {
+                ctx.Database.Initialize(true);
+            }
+        }
+
+        private static string GetMySqlConnString(string username, string password, string host, string db = null)
+        {
+             string connStr = string.Format("User Id={0};Password={1};Host={2};Persist Security Info=True;",
+                username,
+                password,
+                host);
+
+            if (!string.IsNullOrEmpty(db))
+            {
+                connStr+= $"Database={db};";
+            }
+
+            connStr +=
+                "allow user variables=true;" +
+                "persist security info=true;" +
+                "Convert Zero Datetime=True";
+
+            return connStr;
+        }
+
+        [Test]
+        public void SqlServerDbIsCreatedSuccessfully()
+        {
+            using (var conn = new SqlConnection(GetSqlServerConnString("master", _sqlServerHost, _sqlServerUsername, _sqlServerPassword, false, _useWindowsAuthentication)))
+            {
+                conn.Open();
+                using (var cmd = new SqlCommand("", conn))
+                {
+                    cmd.CommandText = @"IF EXISTS(SELECT name FROM sys.databases WHERE name = 'qdms_test')
+                                            DROP DATABASE qdms_test";
+                    cmd.ExecuteNonQuery();
+                    cmd.CommandText = @"IF EXISTS(SELECT name FROM sys.databases WHERE name = 'qdmsdata_test')
+                                            DROP DATABASE qdmsdata_test";
+                    cmd.ExecuteNonQuery();
+                    cmd.CommandText = "CREATE DATABASE qdms_test";
+                    cmd.ExecuteNonQuery();
+                    cmd.CommandText = "CREATE DATABASE qdmsdata_test";
+                    cmd.ExecuteNonQuery();
+                }
+            }
+
+            SetConnectionString("qdmsEntities", GetSqlServerConnString("qdms_test", _sqlServerHost, _sqlServerUsername, _sqlServerPassword, false, _useWindowsAuthentication), "System.Data.SqlClient");
+            SetConnectionString("qdmsDataEntities", GetSqlServerConnString("qdmsdata_test", _sqlServerHost, _sqlServerUsername, _sqlServerPassword, false, _useWindowsAuthentication), "System.Data.SqlClient");
+
+            ConfigurationManager.RefreshSection("connectionStrings");
+
+            using (var ctx = new MyDBContext())
+            {
+                ctx.Database.Initialize(true);
+            }
+
+            using (var ctx = new DataDBContext())
+            {
+                ctx.Database.Initialize(true);
+            }
+        }
+
+        internal static string GetSqlServerConnString(string database, string server, string username = null, string password = null, bool noDB = false, bool useWindowsAuthentication = true)
+        {
+            string connectionString = $"Data Source={server};";
+
+            if (!noDB)
+            {
+                connectionString += $"Initial Catalog={database};";
+            }
+
+            if (!useWindowsAuthentication) //user/pass authentication
+            {
+                connectionString += $"User ID={username};Password={password};";
+            }
+            else //windows authentication
+            {
+                connectionString += "Integrated Security=True;";
+            }
+
+            return connectionString;
+        }
+
+        private static void SetConnectionString(string connName, string connStr, string providerName)
+        {
+            Configuration config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            ConnectionStringSettings conSettings = config.ConnectionStrings.ConnectionStrings[connName];
+
+            //this is an extremely dirty hack that allows us to change the connection string at runtime
+            var fi = typeof(ConfigurationElement).GetField("_bReadOnly", BindingFlags.Instance | BindingFlags.NonPublic);
+            fi.SetValue(conSettings, false);
+
+            conSettings.ConnectionString = connStr;
+            conSettings.ProviderName = providerName;
+
+            config.Save();
+        }
+    }
+}

--- a/QDMSTest/QDMSTest.csproj
+++ b/QDMSTest/QDMSTest.csproj
@@ -71,6 +71,14 @@
       <HintPath>..\packages\Moq.4.5.19\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="MySql.Data, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
+      <HintPath>..\packages\MySql.Data.6.9.9\lib\net45\MySql.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MySql.Data.Entity.EF6, Version=6.9.9.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
+      <HintPath>..\packages\MySql.Data.Entity.6.9.9\lib\net45\MySql.Data.Entity.EF6.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -109,6 +117,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -130,6 +139,7 @@
     <Compile Include="QDMSServer\RealTimeDataServerTest.cs" />
     <Compile Include="QDMSServer\RTHFilterTest.cs" />
     <Compile Include="QDMS\ContinuousFutureTest.cs" />
+    <Compile Include="QDMS\DbCreationTest.cs" />
     <Compile Include="QDMS\InstrumentTest.cs" />
     <Compile Include="QDMS\MyExtensionsTest.cs" />
     <Compile Include="QDMS\MyUtilsTest.cs" />

--- a/QDMSTest/packages.config
+++ b/QDMSTest/packages.config
@@ -6,6 +6,8 @@
   <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
   <package id="MetaLinq" version="1.0.11" targetFramework="net45" />
   <package id="Moq" version="4.5.19" targetFramework="net45" />
+  <package id="MySql.Data" version="6.9.9" targetFramework="net45" />
+  <package id="MySql.Data.Entity" version="6.9.9" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,26 @@ before_package:
 
 # scripts to run after build
 after_build:
-
+  - ps: >-
+      [reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo") | Out-Null
+      [reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.SqlWmiManagement") | Out-Null
+       
+      $instanceName = 'SQL2016'
+      $computerName = $env:COMPUTERNAME
+      $smo = 'Microsoft.SqlServer.Management.Smo.'
+      $wmi = New-Object ($smo + 'Wmi.ManagedComputer')
+      
+      # Enable named pipes
+      $uri = "ManagedComputer[@Name='$serverName']/ ServerInstance[@Name='$instanceName']/ServerProtocol[@Name='Np']"
+      $Np = $wmi.GetSmoObject($uri)
+      $Np.IsEnabled = $true
+      $Np.Alter()
+      
+      # Start services
+      Set-Service SQLBrowser -StartupType Manual
+      Start-Service SQLBrowser
+      Restart-Service "MSSQL`$$instanceName"
+      
 # to run your custom scripts instead of automatic MSBuild
 build_script:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,11 +34,9 @@ cache:
   - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
 
 # enable service required for build/tests
-#services:
-#  - mssql2014           # start SQL Server 2014 Express
-#  - mssql2012sp1        # start SQL Server 2012 SP1 Express
-#  - mssql2008r2sp2      # start SQL Server 2008 R2 SP2 Express
-#  - mysql               # start MySQL 5.6 service
+services:
+  - mysql               # start MySQL 5.6 service
+  - mssql2016
 
 # enable patching of AssemblyInfo.* files
 #assembly_info:


### PR DESCRIPTION
Tried rebuilding the db from scratch after the latest migration additions and it would crash.

The TradingClass issue is that for some reason it would try to remove an index that had a FK on it in mysql, which resulted in a crash. No sure why that was happening.

The IndexFix change is because there's a bug in the mysql provider's DropPrimaryKey() that results in a malformed query and a crash. The fix is ugly but it works.